### PR TITLE
Fixed #7 gatt queuing, issue with readCharacteristic on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,13 +258,14 @@ const emptyResult = await ble.writeCharacteristic(
 
 > [!CAUTION]
 > From version 1.8.0 on the returned subscription object has the type `AsyncSubscription` instead of `Subscription` to indicate that the `remove` method is now async and returns a Promise for better multi-platform compatibility.
+> From version 1.9.0 on the `subscribeToCharacteristic` method is async, so use await when calling it. This was introduced to fix the handling of gatt queuing on Android.
 
 > [!IMPORTANT]  
 > It is only possible to have one active notification subscription per specific characteristic. If you call `subscribeToCharacteristic` again for the same characteristic, the previous subscription won't receive any more updates and should be removed previously.
 
 ```typescript
 // Subscribe to characteristic notifications
-const subscription = ble.subscribeToCharacteristic(
+const subscription = await ble.subscribeToCharacteristic( // before 1.9.0 this was synchronous
   deviceId,
   serviceUUID,
   characteristicUUID,

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -302,7 +302,7 @@ export default function App() {
       await unsubscribeRx?.();
       setBleNotificationSubscription(false);
     }
-    const sub = ble.instance.subscribeToCharacteristic(connectedDeviceId, CUSTOM_SERVICE_UUID, RX_CHAR_UUID, (_, data) => {
+    const sub = await ble.instance.subscribeToCharacteristic(connectedDeviceId, CUSTOM_SERVICE_UUID, RX_CHAR_UUID, (_, data) => {
       logMessage('Received data', JSON.stringify(data));
     });
     logMessage('Subscribed to notifications');
@@ -327,7 +327,7 @@ export default function App() {
       await unsubscribeHr?.();
       setHrNotificationSubscription(false);
     }
-    const sub = ble.instance.subscribeToCharacteristic(connectedDeviceId, HEART_RATE_SERVICE_UUID, HEART_RATE_MEASUREMENT_UUID, (_, data) => {
+    const sub = await ble.instance.subscribeToCharacteristic(connectedDeviceId, HEART_RATE_SERVICE_UUID, HEART_RATE_MEASUREMENT_UUID, (_, data) => {
       const [type, hr] = data;
       logMessage('Heart Rate', hr);
       if (type === 0) return;
@@ -474,6 +474,14 @@ export default function App() {
                               {bleNotificationSubscription && (
                                 <TouchableOpacity style={styles.button} onPress={unlistenToBleNotifications}>
                                   <Text>Stop Listening to BLE Notifications</Text>
+                                </TouchableOpacity>
+                              )}
+                              {!bleNotificationSubscription && !hrNotificationSubscription && (
+                                <TouchableOpacity style={styles.button} onPress={async () => {
+                                  await listenToBleNotifications();
+                                  await listenToHrNotifications();
+                                }}>
+                                  <Text>Listen to HR and Custom Notifications</Text>
                                 </TouchableOpacity>
                               )}
                             </>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - BleNitro (1.7.1):
+  - BleNitro (1.8.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2097,7 +2097,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  BleNitro: b55b68f2555ec5e95c23521d2cdf11b30ea283d4
+  BleNitro: c4b3e877e6b2373e04b7b386fe5962b75c77fdc7
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EXConstants: 9d62a46a36eae6d28cb978efcbc68aef354d1704

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -12,7 +12,7 @@
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-native": "0.79.5",
-        "react-native-ble-nitro": "file:../react-native-ble-nitro-1.7.1.tgz",
+        "react-native-ble-nitro": "file:../react-native-ble-nitro-1.8.0.tgz",
         "react-native-nitro-modules": "^0.30.0",
         "react-native-safe-area-context": "5.4.0"
       },
@@ -6487,9 +6487,9 @@
       }
     },
     "node_modules/react-native-ble-nitro": {
-      "version": "1.7.1",
-      "resolved": "file:../react-native-ble-nitro-1.7.1.tgz",
-      "integrity": "sha512-S/M35NRm1PjZD+m0Ct6Dy6zQb2TLzbY1OwwntLXUqH/NVhYlkQH1XMxZ/DLydjrYG3fKR7A/gs1sm9stYsUFrw==",
+      "version": "1.8.0",
+      "resolved": "file:../react-native-ble-nitro-1.8.0.tgz",
+      "integrity": "sha512-33xW70nvCzOxy9jgW+0FD0oDLHj0CrOC4QerXUsalorSiMVosl19/kIU71+wu4c22IAL+VzPLqgAZ4+J5H8aPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"

--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-native": "0.79.5",
-    "react-native-ble-nitro": "file:../react-native-ble-nitro-1.7.1.tgz",
+    "react-native-ble-nitro": "file:../react-native-ble-nitro-1.8.0.tgz",
     "react-native-nitro-modules": "^0.30.0",
     "react-native-safe-area-context": "5.4.0"
   },

--- a/ios/BleNitroBleManager.swift
+++ b/ios/BleNitroBleManager.swift
@@ -389,22 +389,24 @@ public class BleNitroBleManager: HybridNativeBleNitroSpec {
         deviceId: String,
         serviceId: String,
         characteristicId: String,
-        updateCallback: @escaping (String, ArrayBuffer) -> Void
-    ) throws -> OperationResult {
+        updateCallback: @escaping (String, ArrayBuffer) -> Void,
+        completionCallback: @escaping (Bool, String) -> Void
+    ) throws {
         guard let characteristic = findCharacteristic(deviceId: deviceId, serviceId: serviceId, characteristicId: characteristicId) else {
-            return OperationResult(success: false, error: "Characteristic not found")
+            completionCallback(false, "Characteristic not found")
+            return
         }
 
         // Ensure peripheral delegate exists
         guard let delegate = peripheralDelegates[deviceId] else {
-            return OperationResult(success: false, error: "Device not properly connected or delegate not found")
+            completionCallback(false, "Device not properly connected or delegate not found")
+            return
         }
 
         delegate.notificationCallbacks[characteristic.uuid] = updateCallback
+        delegate.subscriptionCallbacks[characteristic.uuid] = completionCallback
 
         characteristic.service?.peripheral?.setNotifyValue(true, for: characteristic)
-
-        return OperationResult(success: true, error: nil)
     }
 
     public func unsubscribeFromCharacteristic(

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -245,17 +245,17 @@ describe('BleNitro', () => {
     });
     await BleManager.connect('device');
 
-    // Mock subscription - now returns OperationResult
-    mockNative.subscribeToCharacteristic.mockImplementation((_device: string, _service: string, _char: string, updateCallback: (charId: string, data: ArrayBuffer) => void) => {
+    // Mock subscription - now uses completion callback (async)
+    mockNative.subscribeToCharacteristic.mockImplementation((_device: string, _service: string, _char: string, updateCallback: (charId: string, data: ArrayBuffer) => void, completionCallback: (success: boolean, error: string) => void) => {
       // Simulate notification
       const testData = new Uint8Array([1, 2, 3]);
       updateCallback('char-id', testData.buffer);
-      // Return OperationResult
-      return { success: true, error: null };
+      // Call completion callback to signal subscription is established
+      completionCallback(true, '');
     });
 
     const notificationCallback = jest.fn();
-    const subscription = BleManager.subscribeToCharacteristic('device', 'service', 'char', notificationCallback);
+    const subscription = await BleManager.subscribeToCharacteristic('device', 'service', 'char', notificationCallback);
 
     expect(mockNative.subscribeToCharacteristic).toHaveBeenCalled();
     expect(notificationCallback).toHaveBeenCalledWith('char-id', [1, 2, 3]);

--- a/src/specs/NativeBleNitro.nitro.ts
+++ b/src/specs/NativeBleNitro.nitro.ts
@@ -97,7 +97,7 @@ export interface NativeBleNitro extends HybridObject<{ ios: 'swift'; android: 'k
   // Characteristic operations
   readCharacteristic(deviceId: string, serviceId: string, characteristicId: string, callback: ReadCharacteristicCallback): void;
   writeCharacteristic(deviceId: string, serviceId: string, characteristicId: string, data: BLEValue, withResponse: boolean, callback: WriteCharacteristicCallback): void;
-  subscribeToCharacteristic(deviceId: string, serviceId: string, characteristicId: string, updateCallback: CharacteristicCallback): OperationResult;
+  subscribeToCharacteristic(deviceId: string, serviceId: string, characteristicId: string, updateCallback: CharacteristicCallback, completionCallback: OperationCallback): void;
   unsubscribeFromCharacteristic(deviceId: string, serviceId: string, characteristicId: string, callback: OperationCallback): void;
 
   // Bluetooth state management


### PR DESCRIPTION
Introduced async subscriptions to fix problems (Issue #7) with gatt queuing on android, fixed readCharacteristic on android so that it waits for the BLE stack to return the actual read value before resolving. Previously it could happen that first call of readCharacteristic returned empty value and second call resolved correct value.

This will break previous releases as `subscribeToCharacteristic()` was synchronous previously and is now async.