### PR TITLE
fix(ios,android): cancel in-progress connection on disconnect

### DIFF
--- a/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
+++ b/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
@@ -657,6 +657,12 @@ class BleNitroBleManager : HybridNativeBleNitroSpec() {
         try {
             val gatt = connectedDevices[deviceId]
             if (gatt != null) {
+                val callbacks = deviceCallbacks[deviceId]
+                val pendingConnect = callbacks?.connectCallback
+                if (pendingConnect != null) {
+                    pendingConnect.invoke(false, deviceId, "Connection cancelled")
+                    deviceCallbacks[deviceId] = callbacks.copy(connectCallback = null)
+                }
                 gatt.disconnect()
                 callback(true, "")
             } else {

--- a/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
+++ b/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
@@ -266,18 +266,21 @@ class BleNitroBleManager : HybridNativeBleNitroSpec() {
     private fun createGattCallback(deviceId: String): BluetoothGattCallback {
         return object : BluetoothGattCallback() {
             override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
-                val callbacks = deviceCallbacks[deviceId]
-                
                 when (newState) {
                     BluetoothProfile.STATE_CONNECTED -> {
-                        callbacks?.connectCallback?.invoke(true, deviceId, "")
+                        var connectCb: ((Boolean, String, String) -> Unit)? = null
+                        deviceCallbacks.compute(deviceId) { _, callbacks ->
+                            connectCb = callbacks?.connectCallback
+                            callbacks?.copy(connectCallback = null)
+                        }
+                        connectCb?.invoke(true, deviceId, "")
                     }
                     BluetoothProfile.STATE_DISCONNECTED -> {
                         // Clean up
                         connectedDevices.remove(deviceId)
                         val interrupted = status != BluetoothGatt.GATT_SUCCESS
-                        callbacks?.disconnectCallback?.invoke(deviceId, interrupted, if (interrupted) "Connection lost" else "")
-                        deviceCallbacks.remove(deviceId)
+                        val cb = deviceCallbacks.remove(deviceId)
+                        cb?.disconnectCallback?.invoke(deviceId, interrupted, if (interrupted) "Connection lost" else "")
                         gatt.close()
                     }
                 }
@@ -657,12 +660,12 @@ class BleNitroBleManager : HybridNativeBleNitroSpec() {
         try {
             val gatt = connectedDevices[deviceId]
             if (gatt != null) {
-                val callbacks = deviceCallbacks[deviceId]
-                val pendingConnect = callbacks?.connectCallback
-                if (pendingConnect != null) {
-                    pendingConnect.invoke(false, deviceId, "Connection cancelled")
-                    deviceCallbacks[deviceId] = callbacks.copy(connectCallback = null)
+                var pendingConnect: ((Boolean, String, String) -> Unit)? = null
+                deviceCallbacks.compute(deviceId) { _, callbacks ->
+                    pendingConnect = callbacks?.connectCallback
+                    callbacks?.copy(connectCallback = null)
                 }
+                pendingConnect?.invoke(false, deviceId, "Connection cancelled")
                 gatt.disconnect()
                 callback(true, "")
             } else {

--- a/ios/BleNitroBleManager.swift
+++ b/ios/BleNitroBleManager.swift
@@ -260,7 +260,7 @@ public class BleNitroBleManager: HybridNativeBleNitroSpec {
             return
         }
 
-        if peripheral.state != .connected, let delegate = peripheralDelegates[deviceId] {
+        if peripheral.state == .connecting, let delegate = peripheralDelegates[deviceId] {
             delegate.connectionCallback?(false, "", "Connection cancelled")
             delegate.connectionCallback = nil
         }

--- a/ios/BleNitroBleManager.swift
+++ b/ios/BleNitroBleManager.swift
@@ -255,17 +255,22 @@ public class BleNitroBleManager: HybridNativeBleNitroSpec {
     
     public func disconnect(deviceId: String, callback: @escaping (Bool, String) -> Void) throws {
         ensureCentralManager()
-        guard let peripheral = connectedPeripherals[deviceId] else {
-            callback(false, "Peripheral not connected")
+        guard let peripheral = connectedPeripherals[deviceId] ?? findPeripheral(by: deviceId) else {
+            callback(false, "Peripheral not found")
             return
         }
-        
+
+        if peripheral.state != .connected, let delegate = peripheralDelegates[deviceId] {
+            delegate.connectionCallback?(false, "", "Connection cancelled")
+            delegate.connectionCallback = nil
+        }
+
         // Store disconnect callback in delegate
         peripheralDelegates[deviceId]?.disconnectionCallback = callback
-        
+
         // Mark this as an intentional disconnection
         intentionalDisconnections.insert(deviceId)
-        
+
         centralManager.cancelPeripheralConnection(peripheral)
     }
     


### PR DESCRIPTION
`disconnect()` did not clean up properly when called during a pending (not yet established) connection on both platforms. This made it impossible to cancel a connection attempt, for example, when racing `connect()` against a JS-side timeout - a case I want to implement in my app, to scan only for specific amount of time.

### iOS

`disconnect()` gated on `connectedPeripherals[deviceId]`, which is only populated after `didConnect` fires. While the connection was still in progress (`.connecting` state), the guard returned early with `"Peripheral not connected"` without calling `cancelPeripheralConnection`, leaving the peripheral state and the pending callback uncleared.

The fix falls back to the existing `findPeripheral(by:)` helper to locate the peripheral regardless of connection state, rejects the pending `connectionCallback`, and calls `cancelPeripheralConnection`. Because `intentionalDisconnections` is populated beforehand, the resulting `didDisconnectPeripheral` callback does not surface a spurious disconnect event to the application.

### Android

`disconnect()` correctly finds the GATT object (stored synchronously at `connectGatt()` time), and `BluetoothGatt.disconnect()` is documented to cancel pending connections. However, when called during a pending connection, `onConnectionStateChange` fires with `STATE_DISCONNECTED` and only invokes `disconnectCallback`, the `connectCallback` stored in `deviceCallbacks` was removed without ever being called.

The fix captures and invokes `connectCallback` with `"Connection cancelled"` before calling `gatt.disconnect()`, then clears it to prevent a double-invocation if `STATE_CONNECTED` fires concurrently.

## Type of Change
- [x] Bug fix

## Testing
- [x] Tests pass locally
- [x] Tested on iOS
- [x] Tested on Android

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] No breaking changes