### PR TITLE
feat: expose advertised service data in scan results

### DIFF
--- a/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
+++ b/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
@@ -225,14 +225,32 @@ class BleNitroBleManager : HybridNativeBleNitroSpec() {
             ManufacturerData(companyIdentifiers = entries.toTypedArray())
         } ?: ManufacturerData(companyIdentifiers = emptyArray())
         
+        // Extract service data
+        val serviceData = scanRecord?.serviceData?.let { dataMap ->
+            val entries = mutableListOf<ServiceDataEntry>()
+            for ((uuid, value) in dataMap) {
+                // Create direct ByteBuffer as required by ArrayBuffer.wrap()
+                val directBuffer = java.nio.ByteBuffer.allocateDirect(value.size)
+                directBuffer.put(value)
+                directBuffer.flip()
+
+                entries.add(ServiceDataEntry(
+                    uuid = uuid.toString(),
+                    data = ArrayBuffer.wrap(directBuffer)
+                ))
+            }
+            ServiceData(services = entries.toTypedArray())
+        } ?: ServiceData(services = emptyArray())
+
         // Extract service UUIDs
         val serviceUUIDs = scanRecord?.serviceUuids?.map { it.toString() }?.toTypedArray() ?: emptyArray()
-        
+
         return BLEDevice(
             id = device.address,
             name = device.name ?: "",
             rssi = scanResult.rssi.toDouble(),
             manufacturerData = manufacturerData,
+            serviceData = serviceData,
             serviceUUIDs = serviceUUIDs,
             isConnectable = true, // Assume scannable devices are connectable
             isConnected = false // Scanned devices are not yet connected

--- a/ios/BleNitroBleManager.swift
+++ b/ios/BleNitroBleManager.swift
@@ -726,19 +726,36 @@ public class BleNitroBleManager: HybridNativeBleNitroSpec {
         
         // Extract manufacturer data
         let manufacturerData = extractManufacturerData(from: advertisementData)
-        
+
+        // Extract service data
+        let serviceData = extractServiceData(from: advertisementData)
+
         // Check if connectable
         let isConnectable = (advertisementData[CBAdvertisementDataIsConnectable] as? Bool) ?? true
-        
+
         return BLEDevice(
             id: deviceId,
             name: deviceName,
             rssi: rssi,
             manufacturerData: manufacturerData,
+            serviceData: serviceData,
             serviceUUIDs: serviceUUIDs,
             isConnectable: isConnectable,
             isConnected: peripheral.state == .connected
         )
+    }
+
+    private func extractServiceData(from advertisementData: [String: Any]) -> ServiceData {
+        guard let serviceDataRaw = advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID: Data] else {
+            return ServiceData(services: [])
+        }
+
+        let entries: [ServiceDataEntry] = serviceDataRaw.map { (uuid, data) in
+            let arrayBuffer = (try? ArrayBuffer.copy(data: data)) ?? (try! ArrayBuffer.copy(data: Data()))
+            return ServiceDataEntry(uuid: uuid.uuidString, data: arrayBuffer)
+        }
+
+        return ServiceData(services: entries)
     }
     
     private func extractManufacturerData(from advertisementData: [String: Any]) -> ManufacturerData {

--- a/ios/BleNitroBleManager.swift
+++ b/ios/BleNitroBleManager.swift
@@ -164,6 +164,7 @@ public class BleNitroBleManager: HybridNativeBleNitroSpec {
                 name: peripheral.name ?? "Unknown Device",
                 rssi: 0, // RSSI not available for connected devices without explicit read
                 manufacturerData: ManufacturerData(companyIdentifiers: []), // Not available for connected devices
+                serviceData: ServiceData(services: []), // Not available for connected devices
                 serviceUUIDs: peripheral.services?.map { $0.uuid.uuidString } ?? [],
                 isConnectable: true, // Already connected, so it was connectable
                 isConnected: true
@@ -185,12 +186,13 @@ public class BleNitroBleManager: HybridNativeBleNitroSpec {
                     name: peripheral.name ?? "Unknown Device",
                     rssi: 0,
                     manufacturerData: ManufacturerData(companyIdentifiers: []),
+                    serviceData: ServiceData(services: []),
                     serviceUUIDs: peripheral.services?.map { $0.uuid.uuidString } ?? [],
                     isConnectable: true,
                     isConnected: true
                 )
                 connectedDevices.append(device)
-                
+
                 // Add to our tracking dictionary
                 connectedPeripherals[deviceId] = peripheral
             }
@@ -211,6 +213,7 @@ public class BleNitroBleManager: HybridNativeBleNitroSpec {
                         name: peripheral.name ?? "Unknown Device",
                         rssi: 0,
                         manufacturerData: ManufacturerData(companyIdentifiers: []),
+                        serviceData: ServiceData(services: []),
                         serviceUUIDs: peripheral.services?.map { $0.uuid.uuidString } ?? [],
                         isConnectable: true,
                         isConnected: true
@@ -607,6 +610,7 @@ public class BleNitroBleManager: HybridNativeBleNitroSpec {
                     name: peripheral.name ?? "Restored Device",
                     rssi: 0, // RSSI not available for restored peripherals
                     manufacturerData: ManufacturerData(companyIdentifiers: []),
+                    serviceData: ServiceData(services: []),
                     serviceUUIDs: peripheral.services?.map { $0.uuid.uuidString } ?? [],
                     isConnectable: true,
                     isConnected: peripheral.state == .connected

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -85,6 +85,43 @@ describe('BleNitro', () => {
     );
   });
 
+  test('startScan exposes converted service data to the callback', async () => {
+    // Reset any scanning state left over from previous tests
+    mockNative.stopScan.mockImplementation(() => true);
+    BleManager.stopScan();
+
+    const nativeDevice = {
+      id: 'device-1',
+      name: 'Treadmill',
+      rssi: -50,
+      manufacturerData: { companyIdentifiers: [] },
+      serviceData: {
+        services: [
+          {
+            uuid: '1826',
+            data: new Uint8Array([0x01, 0x02, 0x03]).buffer,
+          },
+        ],
+      },
+      serviceUUIDs: ['1826'],
+      isConnectable: true,
+      isConnected: false,
+    };
+
+    mockNative.startScan.mockImplementation((filter, callback) => { // eslint-disable-line @typescript-eslint/no-unused-vars
+      callback(nativeDevice);
+    });
+
+    const scanCallback = jest.fn();
+    BleManager.startScan({}, scanCallback);
+
+    expect(scanCallback).toHaveBeenCalledTimes(1);
+    const device = scanCallback.mock.calls[0][0];
+    expect(device.serviceData.services).toHaveLength(1);
+    expect(device.serviceData.services[0].uuid).toBe('00001826-0000-1000-8000-00805f9b34fb');
+    expect(device.serviceData.services[0].data).toEqual([0x01, 0x02, 0x03]);
+  });
+
   test('stopScan calls native and resolves', async () => {
     // First start a scan to set _isScanning to true
     mockNative.startScan.mockImplementation((filter, callback) => { // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export {
   type ScanCallback,
   type ManufacturerDataEntry,
   type ManufacturerData,
+  type ServiceDataEntry,
+  type ServiceData,
   type ConnectionCallback,
   type DisconnectEventCallback,
   type OperationCallback,

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -44,11 +44,21 @@ export interface ManufacturerData {
   companyIdentifiers: ManufacturerDataEntry[];
 }
 
+export interface ServiceDataEntry {
+  uuid: string;
+  data: ByteArray;
+}
+
+export interface ServiceData {
+  services: ServiceDataEntry[];
+}
+
 export interface BLEDevice {
   id: string;
   name: string;
   rssi: number;
   manufacturerData: ManufacturerData;
+  serviceData: ServiceData;
   serviceUUIDs: string[];
   isConnectable: boolean;
   isConnected: boolean;
@@ -130,6 +140,12 @@ export function convertNativeBleDeviceToBleDevice(nativeBleDevice: NativeBLEDevi
     manufacturerData: {
       companyIdentifiers: nativeBleDevice.manufacturerData.companyIdentifiers.map(entry => ({
         id: entry.id,
+        data: arrayBufferToByteArray(entry.data)
+      }))
+    },
+    serviceData: {
+      services: nativeBleDevice.serviceData.services.map(entry => ({
+        uuid: BleNitroManager.normalizeGattUUID(entry.uuid),
         data: arrayBufferToByteArray(entry.data)
       }))
     }

--- a/src/specs/NativeBleNitro.nitro.ts
+++ b/src/specs/NativeBleNitro.nitro.ts
@@ -22,11 +22,21 @@ export interface ManufacturerData {
   companyIdentifiers: ManufacturerDataEntry[];
 }
 
+export interface ServiceDataEntry {
+  uuid: string;
+  data: BLEValue;
+}
+
+export interface ServiceData {
+  services: ServiceDataEntry[];
+}
+
 export interface BLEDevice {
   id: string;
   name: string;
   rssi: number;
   manufacturerData: ManufacturerData;
+  serviceData: ServiceData;
   serviceUUIDs: string[];
   isConnectable: boolean;
   isConnected: boolean;


### PR DESCRIPTION
## Summary
- Adds a `serviceData` field to the scanned `BLEDevice`, exposing BLE advertising service data in the `startScan` callback.
- Lets consumers filter for service subtypes (e.g. FTMS treadmill/indoor-bike subtype) **without connecting** to every discovered device.
- Mirrors the existing `manufacturerData` plumbing across the Nitro spec, public TypeScript API, and both native platforms.

## Changes
- **Spec** (`NativeBleNitro.nitro.ts`): new `ServiceDataEntry` / `ServiceData` interfaces; `serviceData` added to `BLEDevice`.
- **TypeScript API** (`manager.ts`, `index.ts`): public types, export, and `ArrayBuffer → ByteArray` conversion with normalized service UUIDs.
- **iOS** (`BleNitroBleManager.swift`): reads `CBAdvertisementDataServiceDataKey`.
- **Android** (`BleNitroBleManager.kt`): reads `ScanRecord.serviceData`.

Closes #20

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (added a test asserting service data is converted and surfaced in the scan callback)
- [x] `npm run lint`
- [x] `npm run build` (includes `nitro-codegen`)
- [x] On-device verification of native service-data extraction (requires hardware build)