### PR TITLE
Android: use indication CCCD value for indicate-only characteristics

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -111,6 +111,10 @@ android {
     targetCompatibility JavaVersion.VERSION_1_8
   }
 
+  testOptions {
+    unitTests.returnDefaultValues = true
+  }
+
   sourceSets {
     main {
       if (isNewArchitectureEnabled()) {
@@ -137,4 +141,6 @@ dependencies {
 
   // Add a dependency on NitroModules
   implementation project(":react-native-nitro-modules")
+
+  testImplementation "junit:junit:4.13.2"
 }

--- a/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
+++ b/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
@@ -921,7 +921,17 @@ class BleNitroBleManager : HybridNativeBleNitroSpec() {
 
             val subscriptionKey = "$serviceId:$characteristicId"
 
-            // Write to the CCCD descriptor to enable notifications on the remote device.
+            val supportsNotify =
+                (characteristic.properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY) != 0
+            val supportsIndicate =
+                (characteristic.properties and BluetoothGattCharacteristic.PROPERTY_INDICATE) != 0
+            val cccdValue = if (supportsIndicate && !supportsNotify) {
+                BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
+            } else {
+                BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+            }
+
+            // Write to the CCCD descriptor to enable notifications or indications on the remote device.
             // The update callback is stored only after the descriptor write succeeds
             // so that isSubscribedToCharacteristic reflects actual BLE state.
             val descriptor = characteristic.getDescriptor(UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"))
@@ -930,7 +940,7 @@ class BleNitroBleManager : HybridNativeBleNitroSpec() {
                     GattOperation.WriteDescriptor(
                         gatt = gatt,
                         descriptor = descriptor,
-                        value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE,
+                        value = cccdValue,
                         deviceId = deviceId,
                         callback = { success, error ->
                             if (success) {

--- a/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
+++ b/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
@@ -921,14 +921,13 @@ class BleNitroBleManager : HybridNativeBleNitroSpec() {
 
             val subscriptionKey = "$serviceId:$characteristicId"
 
-            val supportsNotify =
-                (characteristic.properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY) != 0
-            val supportsIndicate =
-                (characteristic.properties and BluetoothGattCharacteristic.PROPERTY_INDICATE) != 0
-            val cccdValue = if (supportsIndicate && !supportsNotify) {
-                BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
-            } else {
-                BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+            val cccdValue = when (cccdSubscriptionMode(characteristic.properties)) {
+                CccdSubscriptionMode.INDICATE -> BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
+                CccdSubscriptionMode.NOTIFY -> BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                CccdSubscriptionMode.UNSUPPORTED -> {
+                    completionCallback(false, "Characteristic does not support notify or indicate")
+                    return
+                }
             }
 
             // Write to the CCCD descriptor to enable notifications or indications on the remote device.

--- a/android/src/main/java/com/margelo/nitro/co/zyke/ble/CccdSubscription.kt
+++ b/android/src/main/java/com/margelo/nitro/co/zyke/ble/CccdSubscription.kt
@@ -1,0 +1,38 @@
+package com.margelo.nitro.co.zyke.ble
+
+import android.bluetooth.BluetoothGattCharacteristic
+
+/**
+ * The delivery mode to request via the CCCD descriptor when subscribing to a
+ * characteristic, derived from the characteristic's declared properties.
+ */
+internal enum class CccdSubscriptionMode {
+    /** Use ENABLE_NOTIFICATION_VALUE (unacknowledged delivery). */
+    NOTIFY,
+
+    /** Use ENABLE_INDICATION_VALUE (acknowledged delivery). */
+    INDICATE,
+
+    /** The characteristic supports neither notify nor indicate. */
+    UNSUPPORTED,
+}
+
+/**
+ * Selects the CCCD subscription mode for a characteristic's [properties] bitmask.
+ *
+ * Notification is preferred when the characteristic supports both notify and
+ * indicate because it is unacknowledged and lower-overhead. Indication is used
+ * only for indicate-only characteristics. This mirrors iOS CoreBluetooth, where
+ * `setNotifyValue(true)` automatically selects the appropriate delivery mode.
+ *
+ * [properties] is the value of [BluetoothGattCharacteristic.getProperties].
+ */
+internal fun cccdSubscriptionMode(properties: Int): CccdSubscriptionMode {
+    val supportsNotify = (properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY) != 0
+    val supportsIndicate = (properties and BluetoothGattCharacteristic.PROPERTY_INDICATE) != 0
+    return when {
+        supportsNotify -> CccdSubscriptionMode.NOTIFY
+        supportsIndicate -> CccdSubscriptionMode.INDICATE
+        else -> CccdSubscriptionMode.UNSUPPORTED
+    }
+}

--- a/android/src/test/java/com/margelo/nitro/co/zyke/ble/CccdSubscriptionTest.kt
+++ b/android/src/test/java/com/margelo/nitro/co/zyke/ble/CccdSubscriptionTest.kt
@@ -1,0 +1,48 @@
+package com.margelo.nitro.co.zyke.ble
+
+import android.bluetooth.BluetoothGattCharacteristic
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [cccdSubscriptionMode].
+ *
+ * `PROPERTY_NOTIFY` and `PROPERTY_INDICATE` are compile-time `int` constants and
+ * are inlined by the compiler, so these tests run on the plain JVM without
+ * Robolectric or a connected device.
+ */
+class CccdSubscriptionTest {
+    private val notify = BluetoothGattCharacteristic.PROPERTY_NOTIFY
+    private val indicate = BluetoothGattCharacteristic.PROPERTY_INDICATE
+    private val read = BluetoothGattCharacteristic.PROPERTY_READ
+
+    @Test
+    fun notifyOnly_usesNotify() {
+        assertEquals(CccdSubscriptionMode.NOTIFY, cccdSubscriptionMode(notify))
+    }
+
+    @Test
+    fun indicateOnly_usesIndicate() {
+        assertEquals(CccdSubscriptionMode.INDICATE, cccdSubscriptionMode(indicate))
+    }
+
+    @Test
+    fun supportsBoth_prefersNotify() {
+        assertEquals(CccdSubscriptionMode.NOTIFY, cccdSubscriptionMode(notify or indicate))
+    }
+
+    @Test
+    fun indicateWithOtherProperties_usesIndicate() {
+        assertEquals(CccdSubscriptionMode.INDICATE, cccdSubscriptionMode(indicate or read))
+    }
+
+    @Test
+    fun neitherNotifyNorIndicate_isUnsupported() {
+        assertEquals(CccdSubscriptionMode.UNSUPPORTED, cccdSubscriptionMode(read))
+    }
+
+    @Test
+    fun noProperties_isUnsupported() {
+        assertEquals(CccdSubscriptionMode.UNSUPPORTED, cccdSubscriptionMode(0))
+    }
+}


### PR DESCRIPTION
The Android subscription path currently writes the ENABLE_NOTIFICATION_VALUE CCCD value for every characteristic. That fails for indicate-only characteristics because the peer expects ENABLE_INDICATION_VALUE. This differs from iOS CoreBluetooth, where setNotifyValue(true) selects the appropriate delivery mode.

The fix: inspect characteristic properties and use ENABLE_INDICATION_VALUE when the characteristic supports indicate but not notify; otherwise keep the existing notification behavior.