### PR TITLE
feat(android): add requestConnectionPriority API

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ npx pod-install # iOS only
 ### Basic Setup
 
 ```typescript
-import { BleNitro, BleNitroManager, BLEState, AndroidScanMode, type BLEDevice } from 'react-native-ble-nitro';
+import { BleNitro, BleNitroManager, BLEState, AndroidScanMode, AndroidConnectionPriority, type BLEDevice } from 'react-native-ble-nitro';
 
 // Get the singleton instance
 const ble = BleNitro.instance();
@@ -159,6 +159,12 @@ const deviceId = await ble.connect(deviceId, (deviceId, interrupted, error) => {
 // Connect without disconnect callback
 const deviceId = await ble.connect(deviceId);
 
+// Request lower-latency connection parameters while connected (Android only)
+const priorityRequested = ble.requestConnectionPriority(
+  deviceId,
+  AndroidConnectionPriority.High
+);
+
 // You can also use findAndConnect to scan and connect in one step
 // This could be useful for reconnecting after app restart or when device was disconnected unexpectedly
 const deviceId = await ble.findAndConnect(deviceId, {
@@ -188,6 +194,10 @@ const mtu = await ble.requestMTU(deviceId, 256); // Request MTU size
 // iOS manages MTU automatically, this method returns current MTU size
 const newMTU = ble.requestMTU(deviceId, 247);
 console.log('MTU set to:', newMTU);
+
+// Request Android connection priority while connected
+// Returns true if Android accepted the request; returns false on iOS or error
+const priorityRequested = ble.requestConnectionPriority(deviceId, AndroidConnectionPriority.High);
 
 // Read RSSI value
 const rssi = await ble.readRSSI(deviceId);
@@ -311,6 +321,7 @@ const deviceId = await ble.connect(
   },
   autoConnectOnAndroid,
 );
+ble.requestConnectionPriority(deviceId, AndroidConnectionPriority.High);
 await ble.discoverServices(deviceId);
 
 const subscription = await ble.subscribeToCharacteristic(
@@ -460,6 +471,12 @@ enum AndroidScanMode {
   Balanced = 'Balanced',            // Balanced power/discovery (default)
   LowPower = 'LowPower',            // Lowest power, slower discovery  
   Opportunistic = 'Opportunistic',  // Only when other apps are scanning
+}
+
+enum AndroidConnectionPriority {
+  Balanced = 'Balanced', // Balanced connection interval
+  High = 'High',         // Lower latency, higher power
+  LowPower = 'LowPower', // Lower power, higher latency
 }
 
 // Callback types

--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ const newMTU = ble.requestMTU(deviceId, 247);
 console.log('MTU set to:', newMTU);
 
 // Request Android connection priority while connected
-// Returns true if Android accepted the request; returns false on iOS or error
+// Returns true if Android successfully initiated the request (the priority change
+// is applied asynchronously); returns false on iOS, an error, or a disconnected device
 const priorityRequested = ble.requestConnectionPriority(deviceId, AndroidConnectionPriority.High);
 
 // Read RSSI value

--- a/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
+++ b/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
@@ -709,8 +709,6 @@ class BleNitroBleManager : HybridNativeBleNitroSpec() {
         return try {
             val gatt = connectedDevices[deviceId] ?: return false
             gatt.requestConnectionPriority(mapAndroidConnectionPriority(androidConnectionPriority))
-        } catch (_: SecurityException) {
-            false
         } catch (_: Exception) {
             false
         }

--- a/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
+++ b/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
@@ -397,6 +397,14 @@ class BleNitroBleManager : HybridNativeBleNitroSpec() {
         }
     }
 
+    private fun mapAndroidConnectionPriority(androidConnectionPriority: AndroidConnectionPriority): Int {
+        return when (androidConnectionPriority) {
+            AndroidConnectionPriority.HIGH -> BluetoothGatt.CONNECTION_PRIORITY_HIGH
+            AndroidConnectionPriority.LOWPOWER -> BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER
+            AndroidConnectionPriority.BALANCED -> BluetoothGatt.CONNECTION_PRIORITY_BALANCED
+        }
+    }
+
     /**
      * Enqueue a GATT operation to be executed sequentially.
      * Android BLE requires that only one GATT operation runs at a time.
@@ -694,6 +702,17 @@ class BleNitroBleManager : HybridNativeBleNitroSpec() {
             }
         } catch (e: Exception) {
             0.0
+        }
+    }
+
+    override fun requestConnectionPriority(deviceId: String, androidConnectionPriority: AndroidConnectionPriority): Boolean {
+        return try {
+            val gatt = connectedDevices[deviceId] ?: return false
+            gatt.requestConnectionPriority(mapAndroidConnectionPriority(androidConnectionPriority))
+        } catch (_: SecurityException) {
+            false
+        } catch (_: Exception) {
+            false
         }
     }
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -2,7 +2,7 @@ import { StatusBar } from 'expo-status-bar';
 import { AppState, PermissionsAndroid, Platform, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { createBle } from './src/bluetooth';
 import { useLayoutEffect, useRef, useState } from 'react';
-import type { BLEDevice, AsyncSubscription } from 'react-native-ble-nitro';
+import { AndroidConnectionPriority, type BLEDevice, type AsyncSubscription } from 'react-native-ble-nitro';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 const HEART_RATE_SERVICE_UUID = '0000180d-0000-1000-8000-00805f9b34fb'.toLowerCase();
@@ -273,6 +273,14 @@ export default function App() {
     }
     const mtu = ble.instance.requestMTU(connectedDeviceId, 517);
     logMessage('MTU', mtu);
+  };
+
+  const requestConnectionPriority = (priority: AndroidConnectionPriority) => {
+    if (!connectedDeviceId) {
+      throw new Error('No device connected');
+    }
+    const accepted = ble.instance.requestConnectionPriority(connectedDeviceId, priority);
+    logMessage(`Connection Priority (${priority})`, accepted ? 'accepted' : 'rejected');
   };
 
   const stringFromBytes = (bytes: number[]) => {
@@ -647,6 +655,15 @@ export default function App() {
                       ))}
                       <TouchableOpacity style={styles.button} onPress={requestMtu}>
                         <Text>Request MTU</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity style={styles.button} onPress={() => requestConnectionPriority(AndroidConnectionPriority.High)}>
+                        <Text>Priority: High (Android)</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity style={styles.button} onPress={() => requestConnectionPriority(AndroidConnectionPriority.Balanced)}>
+                        <Text>Priority: Balanced (Android)</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity style={styles.button} onPress={() => requestConnectionPriority(AndroidConnectionPriority.LowPower)}>
+                        <Text>Priority: Low Power (Android)</Text>
                       </TouchableOpacity>
                       <TouchableOpacity style={styles.button} onPress={readRSSI}>
                         <Text>Read RSSI</Text>

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,6 +1,6 @@
 import { registerRootComponent } from 'expo';
 
-import App from './WhApp';
+import App from './App';
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -13,7 +13,7 @@
         "expo-status-bar": "~55.0.4",
         "react": "19.2.0",
         "react-native": "0.83.2",
-        "react-native-ble-nitro": "file:../react-native-ble-nitro-1.11.0.tgz",
+        "react-native-ble-nitro": "file:../react-native-ble-nitro-1.13.0.tgz",
         "react-native-nitro-modules": "^0.35.0",
         "react-native-safe-area-context": "~5.6.2"
       },
@@ -6033,9 +6033,9 @@
       }
     },
     "node_modules/react-native-ble-nitro": {
-      "version": "1.11.0",
-      "resolved": "file:../react-native-ble-nitro-1.11.0.tgz",
-      "integrity": "sha512-ph+5jqfY2KMwEzjaD+GWpd7f0TifWcpVPOKbj7xAyNoM4+70k9fn6L37tJQ5mrJJiKTD8qGmn4Xb4fApE7k6NQ==",
+      "version": "1.13.0",
+      "resolved": "file:../react-native-ble-nitro-1.13.0.tgz",
+      "integrity": "sha512-q2Dt9b1WJRVddbINymi7FeG2CemVuLpSPLnapY1PsfhNdxuv8ovvFqBfSFUSLc9AdvTj48gVURmhROH4Z/i2Mg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "expo-status-bar": "~55.0.4",
     "react": "19.2.0",
     "react-native": "0.83.2",
-    "react-native-ble-nitro": "file:../react-native-ble-nitro-1.11.0.tgz",
+    "react-native-ble-nitro": "file:../react-native-ble-nitro-1.13.0.tgz",
     "react-native-nitro-modules": "^0.35.0",
     "react-native-safe-area-context": "~5.6.2"
   },

--- a/ios/BleNitroBleManager.swift
+++ b/ios/BleNitroBleManager.swift
@@ -289,6 +289,10 @@ public class BleNitroBleManager: HybridNativeBleNitroSpec {
         
         return Double(peripheral.maximumWriteValueLength(for: .withoutResponse))
     }
+
+    public func requestConnectionPriority(deviceId: String, androidConnectionPriority: AndroidConnectionPriority) throws -> Bool {
+        return false
+    }
     
     public func readRSSI(deviceId: String, callback: @escaping (Bool, Double, String) -> Void) throws {
         guard let peripheral = connectedPeripherals[deviceId] else {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -9,6 +9,7 @@ const createMockNativeModule = () => ({
   connect: jest.fn(),
   disconnect: jest.fn(),
   isConnected: jest.fn(),
+  requestConnectionPriority: jest.fn(),
   
   // Service discovery
   discoverServices: jest.fn(),

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -8,6 +8,7 @@ const mockNativeInstance = {
   disconnect: jest.fn(),
   isConnected: jest.fn(),
   requestMTU: jest.fn(),
+  requestConnectionPriority: jest.fn(),
   readRSSI: jest.fn(),
   discoverServices: jest.fn(),
   discoverServicesWithCharacteristics: jest.fn(),
@@ -44,6 +45,11 @@ jest.mock('../specs/NativeBleNitro', () => ({
     LowPower: 2,
     Opportunistic: 3
   },
+  AndroidConnectionPriority: {
+    Balanced: 0,
+    High: 1,
+    LowPower: 2,
+  },
 }));
 
 jest.mock('../specs/NativeBleNitroFactory', () => ({
@@ -53,7 +59,7 @@ jest.mock('../specs/NativeBleNitroFactory', () => ({
   },
 }));
 
-import { BleNitro } from '../index';
+import { AndroidConnectionPriority, BleNitro } from '../index';
 
 // Get reference to the mocked module
 const mockNative = mockNativeInstance;
@@ -112,6 +118,30 @@ describe('BleNitro', () => {
 
     expect(mockNative.connect).toHaveBeenCalledWith(deviceId, expect.any(Function), undefined, false);
     expect(result).toBe(deviceId);
+  });
+
+  test('connect keeps positional autoConnectAndroid compatibility', async () => {
+    const deviceId = 'test-device-autoconnect';
+    mockNative.connect.mockImplementation((id: string, callback: (success: boolean, deviceId: string, error: string) => void) => {
+      callback(true, id, '');
+    });
+
+    const result = await BleManager.connect(deviceId, undefined, true);
+
+    expect(mockNative.connect).toHaveBeenCalledWith(deviceId, expect.any(Function), undefined, true);
+    expect(result).toBe(deviceId);
+  });
+
+  test('requestConnectionPriority delegates to native with mapped priority', () => {
+    mockNative.requestConnectionPriority.mockReturnValueOnce(true);
+
+    const result = BleManager.requestConnectionPriority(
+      'test-device-priority',
+      AndroidConnectionPriority.High
+    );
+
+    expect(mockNative.requestConnectionPriority).toHaveBeenCalledWith('test-device-priority', 1);
+    expect(result).toBe(true);
   });
 
   test('connect rejects on error', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export {
   type BleNitroManagerOptions,
   BLEState,
   AndroidScanMode,
+  AndroidConnectionPriority,
   BleNitroManager,
   BleTimeoutError,
 } from "./manager";

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -425,16 +425,18 @@ export class BleNitroManager {
   /**
    * Request an Android connection priority for an active connection.
    * @param deviceId ID of the device
-   * @param androidConnectionPriority Desired Android connection priority
-   * @returns On Android: true if the request was accepted; on iOS or error: false
+   * @param priority Desired Android connection priority
+   * @returns On Android: true if the request was successfully initiated (the
+   *   priority change itself is applied asynchronously); on iOS, an error, or a
+   *   disconnected device: false
    */
   public requestConnectionPriority(
     deviceId: string,
-    androidConnectionPriority: AndroidConnectionPriority
+    priority: AndroidConnectionPriority
   ): boolean {
     return this.Instance.requestConnectionPriority(
       deviceId,
-      mapAndroidConnectionPriorityToNativeAndroidConnectionPriority(androidConnectionPriority)
+      mapAndroidConnectionPriorityToNativeAndroidConnectionPriority(priority)
     );
   }
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -5,6 +5,7 @@ import {
   BLEState as NativeBLEState,
   ScanCallback as NativeScanCallback,
   AndroidScanMode as NativeAndroidScanMode,
+  AndroidConnectionPriority as NativeAndroidConnectionPriority,
 } from './specs/NativeBleNitro';
 
 export class BleTimeoutError extends Error {
@@ -96,6 +97,12 @@ export enum AndroidScanMode {
   Opportunistic = 'Opportunistic',
 }
 
+export enum AndroidConnectionPriority {
+  Balanced = 'Balanced',
+  High = 'High',
+  LowPower = 'LowPower',
+}
+
 export type BleNitroManagerOptions = {
   restoreIdentifier?: string;
   onRestoredState?: RestoreStateCallback;
@@ -121,6 +128,15 @@ export function mapAndroidScanModeToNativeAndroidScanMode(scanMode: AndroidScanM
     Opportunistic: NativeAndroidScanMode.Opportunistic,
   }
   return map[scanMode];
+}
+
+export function mapAndroidConnectionPriorityToNativeAndroidConnectionPriority(priority: AndroidConnectionPriority): NativeAndroidConnectionPriority {
+  const map = {
+    Balanced: NativeAndroidConnectionPriority.Balanced,
+    High: NativeAndroidConnectionPriority.High,
+    LowPower: NativeAndroidConnectionPriority.LowPower,
+  }
+  return map[priority];
 }
 
 export function convertNativeBleDeviceToBleDevice(nativeBleDevice: NativeBLEDevice): BLEDevice {
@@ -404,6 +420,22 @@ export class BleNitroManager {
     mtu = parseInt(mtu.toString(), 10);
     const deviceMtu = this.Instance.requestMTU(deviceId, mtu);
     return deviceMtu;
+  }
+
+  /**
+   * Request an Android connection priority for an active connection.
+   * @param deviceId ID of the device
+   * @param androidConnectionPriority Desired Android connection priority
+   * @returns On Android: true if the request was accepted; on iOS or error: false
+   */
+  public requestConnectionPriority(
+    deviceId: string,
+    androidConnectionPriority: AndroidConnectionPriority
+  ): boolean {
+    return this.Instance.requestConnectionPriority(
+      deviceId,
+      mapAndroidConnectionPriorityToNativeAndroidConnectionPriority(androidConnectionPriority)
+    );
   }
 
   /**

--- a/src/specs/NativeBleNitro.nitro.ts
+++ b/src/specs/NativeBleNitro.nitro.ts
@@ -39,6 +39,12 @@ export enum AndroidScanMode {
   Opportunistic = 3,
 }
 
+export enum AndroidConnectionPriority {
+  Balanced = 0,
+  High = 1,
+  LowPower = 2,
+}
+
 export interface ScanFilter {
   serviceUUIDs: string[];
   rssiThreshold: number;
@@ -88,6 +94,7 @@ export interface NativeBleNitro extends HybridObject<{ ios: 'swift'; android: 'k
   disconnect(deviceId: string, callback: OperationCallback): void;
   isConnected(deviceId: string): boolean;
   requestMTU(deviceId: string, mtu: number): number;
+  requestConnectionPriority(deviceId: string, androidConnectionPriority: AndroidConnectionPriority): boolean;
   readRSSI(deviceId: string, callback: ReadRSSICallback): void;
 
   // Service discovery


### PR DESCRIPTION
## Summary

Adds an explicit API for requesting Android BLE connection priority while a device is already connected.

This exposes Android's `BluetoothGatt.requestConnectionPriority(...)` through the JS API instead of changing the default connection behavior or forcing high priority for every connection.

## Motivation

Some BLE workflows need lower latency only during specific phases, such as a burst of reads/writes after connection. Requesting high priority for every connection is not always desirable because it can increase power usage.

Making this a standalone method lets callers opt in when needed and switch priority while the connection is open.

## API

```ts
ble.requestConnectionPriority(deviceId, AndroidConnectionPriority.High);
ble.requestConnectionPriority(deviceId, AndroidConnectionPriority.Balanced);
ble.requestConnectionPriority(deviceId, AndroidConnectionPriority.LowPower);