### PR TITLE
fix: Android build failed

### DIFF
--- a/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
+++ b/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt
@@ -693,6 +693,7 @@ class BleNitroBleManager : HybridNativeBleNitroSpec() {
                     name = device.name ?: "",
                     rssi = 0.0, // RSSI not available for already connected devices
                     manufacturerData = ManufacturerData(companyIdentifiers = emptyArray()),
+                    serviceData = ServiceData(services = emptyArray()),
                     serviceUUIDs = emptyArray(), // Service UUIDs not available without service discovery
                     isConnectable = true,
                     isConnected = true


### PR DESCRIPTION
e: file:///E:/workspace/Demo/node_modules/react-native-ble-nitro/android/src/main/java/com/margelo/nitro/co/zyke/ble/BleNitroBleManager.kt:698:21 No value passed for parameter 'serviceData'.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-ble-nitro:compileDebugKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Compilation error. See log for more details